### PR TITLE
remove extraneous argument to use_ok

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -5,7 +5,7 @@ use Test::More;
 use feature qw/say/;
 
 BEGIN {
-    use_ok('UNIVERSAL::Object', 'patch_parent');
+    use_ok('UNIVERSAL::Object');
     use_ok('Moonshine::Element');
 }
                                                        


### PR DESCRIPTION
use_ok does not accept a test name, but passes its extra arguments to the module's import method. Perl has always ignored these extraneous arguments, but future versions are intending to make it an error to pass arguments to an undefined import method.